### PR TITLE
test: Hande return value type properly

### DIFF
--- a/t/xs.t
+++ b/t/xs.t
@@ -31,15 +31,15 @@ test2(unsigned char input_value)
   ffi_cif         ffi_cif;
   ffi_type       *args[1];
   void           *values[1];
-  unsigned char   return_value;
+  ffi_arg         return_value;
   
   args[0] = &ffi_type_uint8;
   
-  if(ffi_prep_cif(&ffi_cif, FFI_DEFAULT_ABI, 1, &ffi_type_uint8, args) == FFI_OK)
+  if(ffi_prep_cif(&ffi_cif, FFI_DEFAULT_ABI, 1, &ffi_type_uchar, args) == FFI_OK)
   {
     values[0] = &input_value;
     ffi_call(&ffi_cif, FFI_FN(doublechaar), &return_value, values);
-    return return_value;
+    return (int)(unsigned char)return_value;
   }
   return -1;
 }


### PR DESCRIPTION
t/xs.t test failed on big-endian. The return_value after ffi_call()
was always 0. Big endian systems have the least siginicant byte at the
end of a word and interpreting a signed char memory as an integer
must take that offset into account.

This was not the case of the t/xs.t where doublechaar() returned
unsigned char but return_value was of int type and thus libffi stored
the value at a wrong offset.

Moreover the libffi was not properly used because a storage size of a libffi
return value must always be at least sizeof(ffi_arg) large and that's
not true for an unsigned char variable.

This patch fixes it.

Signed-off-by: Petr Písař <ppisar@redhat.com>